### PR TITLE
Update ansible.cfg - typo in deprecation_warnings

### DIFF
--- a/lesson2/ansible.cfg
+++ b/lesson2/ansible.cfg
@@ -2,7 +2,7 @@
 inventory = inventory
 remote_user = ansible
 host_key_checking = false
-deprecation_warning = false
+deprecation_warnings = false
 
 [privilege_escalation] 
 become = True


### PR DESCRIPTION
typo in deprecation warning statement. correct: deprecation_warnings